### PR TITLE
racket(ラケット)の管理画面の作成

### DIFF
--- a/app/admin/rackets.rb
+++ b/app/admin/rackets.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register Racket do
+  permit_params :name, :price, :kind, :user_id
+end

--- a/app/models/racket.rb
+++ b/app/models/racket.rb
@@ -1,0 +1,3 @@
+class Racket < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ApplicationRecord
+  has_many :rackets
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,9 +4,16 @@ ja:
       user: 'ユーザー'
       comment: 'コメント'
       admin_user: '管理者'
+      racket: 'ラケット'
     attributes:
       user:
         name: '名前'
         age: '年齢'
         career: '卓球歴'
         senkei: '戦型'
+        created_at: '作成日時'
+        updated_at: '更新日時'
+      racket:
+        name: '名前'
+        price: '価格'
+        type: '種類'

--- a/db/migrate/20190313065814_create_rackets.rb
+++ b/db/migrate/20190313065814_create_rackets.rb
@@ -1,0 +1,10 @@
+class CreateRackets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :rackets do |t|
+      t.string :name
+      t.integer :price
+      t.string :type
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190313072058_add_user_id_to_rackets.rb
+++ b/db/migrate/20190313072058_add_user_id_to_rackets.rb
@@ -1,0 +1,5 @@
+class AddUserIdToRackets < ActiveRecord::Migration[5.2]
+  def change
+    add_column :rackets, :user_id, :integer, after: :price
+  end
+end

--- a/db/migrate/20190313082751_rename_type_column_to_rackets.rb
+++ b/db/migrate/20190313082751_rename_type_column_to_rackets.rb
@@ -1,0 +1,5 @@
+class RenameTypeColumnToRackets < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :rackets, :type, :kind
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_12_173834) do
+ActiveRecord::Schema.define(version: 2019_03_13_082751) do
 
   create_table "active_admin_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "namespace"
@@ -36,6 +36,15 @@ ActiveRecord::Schema.define(version: 2019_03_12_173834) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
+
+  create_table "rackets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.integer "price"
+    t.integer "user_id"
+    t.string "kind"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/test/fixtures/rackets.yml
+++ b/test/fixtures/rackets.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/racket_test.rb
+++ b/test/models/racket_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RacketTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 目的
ユーザーに紐づいたラケットのデータを作成し、管理画面でCRUD処理出来るようにする。

## やったこと
- racketモデルを作成、migrate
- permit_paramsにname,price,kind,user_idを追加
- userモデルとのリレーションを定義
- racketsテーブルにuser_idカラムを追加
- typeカラムをkindカラムに変更

## 補足
typeはカラム名に使えないことがわかったので、今後はkindというカラム名に置き換えて使用する。