### PR TITLE
racketsテーブルに購入日カラムの追加と購入日をカレンダー表示に設定

### DIFF
--- a/app/admin/rackets.rb
+++ b/app/admin/rackets.rb
@@ -1,3 +1,14 @@
 ActiveAdmin.register Racket do
-  permit_params :name, :price, :kind, :user_id
+  permit_params :name, :price, :kind, :purchase_date, :user_id
+
+  form do |f|
+    f.inputs do
+      f.input :name
+      f.input :price
+      f.input :kind
+      f.input :purchase_date, as: :datepicker
+      f.input :user
+    end
+    f.actions
+  end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,4 +16,8 @@ ja:
       racket:
         name: '名前'
         price: '価格'
-        type: '種類'
+        kind: '種類'
+        user: '所有者'
+        purchase_date: '購入日'
+        created_at: '作成日時'
+        updated_at: '更新日時'

--- a/db/migrate/20190313085950_add_purchase_date_to_rackets.rb
+++ b/db/migrate/20190313085950_add_purchase_date_to_rackets.rb
@@ -1,0 +1,5 @@
+class AddPurchaseDateToRackets < ActiveRecord::Migration[5.2]
+  def change
+    add_column :rackets, :purchase_date, :date, after: :kind
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_13_082751) do
+ActiveRecord::Schema.define(version: 2019_03_13_085950) do
 
   create_table "active_admin_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "namespace"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2019_03_13_082751) do
     t.integer "price"
     t.integer "user_id"
     t.string "kind"
+    t.date "purchase_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
## 目的
racketsテーブルに購入日カラムを追加して、購入日をカレンダー表示になるように設定する。

## やったこと
- 購入日＝purchase_date カラムをracketsテーブルに追加、migrate
- permit_paramsにpurchase_date カラムを追加
- 購入日をカレンダー表示で編集、表示できるようにapp/admin/rackets.rbを加筆修正する（DatePickerを使用)

## 懸念事項
◯使いにくいと感じた点
- カレンダーで月ごとにしか遡って選べず、1,2年前に一気にジャンプしたくてもできない
- 新規作成画面で購入日の欄をクリックすると、前回の入力分が表示されカレンダーを選ぶときに邪魔になる