### PR TITLE
ユーザー一覧に各ユーザーのラケット所持数の列を追加

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,3 +1,18 @@
 ActiveAdmin.register User do
   permit_params :name, :age, :career, :senkei
+
+  index do
+    selectable_column
+    id_column
+    column :name
+    column :age
+    column :career
+    column :senkei
+    column 'ラケット所持数' do |user|
+      user.rackets.count
+    end
+    column :created_at
+    column :updated_at
+    actions
+  end
 end


### PR DESCRIPTION
## 目的
ユーザー一覧に各ユーザーのラケット所持数の列を追加して、誰が何本ラケットを持っているか表示出来るようにする。

## やったこと
- app/admin/racket.rbにデフォルトと同じ表示にする。
- 所属するラケット所持数のカラムを追加する