### PR TITLE
ユーザーの詳細画面に、ユーザーの所持しているラケットの詳細な一覧を表示

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -15,4 +15,17 @@ ActiveAdmin.register User do
     column :updated_at
     actions
   end
+
+  show do |user|
+    attributes_table(*user.class.columns.collect { |column| column.name.to_sym })
+    panel '所持ラケット一覧' do
+      table_for user.rackets do
+        column :name
+        column :price
+        column :kind
+        column :purchase_date
+      end
+    end
+    active_admin_comments
+  end
 end


### PR DESCRIPTION
## 目的
ユーザーの詳細画面に、ユーザーの所持しているラケットの詳細な一覧を表示させる

## やったこと
- app/admin/user.rbに詳細ページのコードを追加
- 所持ラケットの詳細一覧テーブルを表示させるコードを追加

### 参考URL
Railsで最速で管理画面を作る！
https://qiita.com/enomotodev/items/5f6d9348207124a41bf9

### 気になったこと
表示する列の幅が広すぎる。もっと必要最小限にカラムの幅を狭くして全体的に見やすくなればなお良いのだが…。